### PR TITLE
add aria to select

### DIFF
--- a/addon/components/bg-select/component.js
+++ b/addon/components/bg-select/component.js
@@ -4,7 +4,7 @@ import layout from './template';
 export default Component.extend({
   tagName: 'select',
   selectedOptionId: null,
-  attributeBindings: ['aria-labeledby', 'disabled', 'tabindex'],
+  attributeBindings: ['aria-labelledby', 'disabled', 'tabindex'],
   tabindex: null,
   init() {
     this._super();

--- a/addon/components/bg-select/component.js
+++ b/addon/components/bg-select/component.js
@@ -4,7 +4,7 @@ import layout from './template';
 export default Component.extend({
   tagName: 'select',
   selectedOptionId: null,
-  attributeBindings: ['aria-labelledby', 'disabled', 'tabindex'],
+  attributeBindings: ['aria-label', 'disabled', 'tabindex'],
   tabindex: null,
   init() {
     this._super();

--- a/addon/components/bg-select/component.js
+++ b/addon/components/bg-select/component.js
@@ -4,7 +4,7 @@ import layout from './template';
 export default Component.extend({
   tagName: 'select',
   selectedOptionId: null,
-  attributeBindings: ['disabled', 'tabindex'],
+  attributeBindings: ['aria-labeledby', 'disabled', 'tabindex'],
   tabindex: null,
   init() {
     this._super();

--- a/app/components/bg-option/component.js
+++ b/app/components/bg-option/component.js
@@ -1,1 +1,1 @@
-export { default } from 'bg-select/components/bg-option/component';
+export {default} from 'bg-select/components/bg-option/component';

--- a/app/components/bg-select/component.js
+++ b/app/components/bg-select/component.js
@@ -1,1 +1,1 @@
-export { default } from 'bg-select/components/bg-select/component';
+export {default} from 'bg-select/components/bg-select/component';

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,7 +2,7 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
+module.exports = function () {
   return Promise.all([
     getChannelURL('release'),
     getChannelURL('beta'),

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
+module.exports = function (/* environment, appConfig */) {
   return { };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,8 +4,8 @@
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
+module.exports = function (defaults) {
+  const app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bg-select",
-  "version": "0.0.0",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -614,8 +614,7 @@
     "babel-plugin-htmlbars-inline-precompile": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.6.tgz",
-      "integrity": "sha512-H4H75TKGUFij8ukwEYWEERAgrUf16R8NSK1uDPe3QwxT8mnE1K8+/s6DVjUqbM5Pv6lSIcE4XufXdlSX+DTB6g==",
-      "dev": true
+      "integrity": "sha512-H4H75TKGUFij8ukwEYWEERAgrUf16R8NSK1uDPe3QwxT8mnE1K8+/s6DVjUqbM5Pv6lSIcE4XufXdlSX+DTB6g=="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -3024,7 +3023,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.4.tgz",
       "integrity": "sha512-WSGODKKG65M/Q7QcLflmxnJKMA32JqFLyX0a5ghMRDWRqvUVkKWSZDbjJsNsCw/OCeBbPWQLQWq0wtpCnTTjwA==",
-      "dev": true,
       "requires": {
         "broccoli-persistent-filter": "^1.4.3",
         "hash-for-dep": "^1.2.3",
@@ -3035,8 +3033,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -3044,7 +3041,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.3.tgz",
       "integrity": "sha1-My/5bAb8UillFi8QkNeKYVN5w8I=",
-      "dev": true,
       "requires": {
         "babel-plugin-htmlbars-inline-precompile": "^0.2.5",
         "ember-cli-version-checker": "^2.1.2",
@@ -8432,7 +8428,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true,
       "requires": {
         "debug": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bg-select",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Ember cli select component",
   "keywords": [
     "ember-addon"

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,11 +1,11 @@
-import { module, test } from 'qunit';
-import { visit, fillIn, find } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import {module, test} from 'qunit';
+import {visit, fillIn, find} from '@ember/test-helpers';
+import {setupApplicationTest} from 'ember-qunit';
 
-module('Acceptance | application', function(hooks) {
+module('Acceptance | application', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting /', async function(assert) {
+  test('visiting /', async function (assert) {
     await visit('/');
 
     await fillIn('.dummy select', 'yellow');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,7 +6,7 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL
 });
 
-Router.map(function() {
+Router.map(function () {
 });
 
 export default Router;

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,3 @@
+.row > h2 {
+  margin-left: 15px;
+}

--- a/tests/dummy/app/templates/components/dummy-component.hbs
+++ b/tests/dummy/app/templates/components/dummy-component.hbs
@@ -35,7 +35,6 @@
 <div class="row">
   <h2>Result</h2>
   <div class="col-xs-3">
-    <label class="sr-only" id="dropdown-label">Select a colour</label>
     {{#bg-select class="form-control"
       onSelectChange=(action 'onChangeHandler')
       aria-label="Select a colour"

--- a/tests/dummy/app/templates/components/dummy-component.hbs
+++ b/tests/dummy/app/templates/components/dummy-component.hbs
@@ -1,8 +1,8 @@
 <div>
   <h1>Example 1 working with objects</h1>
-  <p>
-    In this example the seed is:
-  </p>
+  <h2>
+    Seed (JS)
+  </h2>
 
   <pre>
     model = {
@@ -16,14 +16,13 @@
         id: 12,
         label: 'red'
       }],
+
       // just to make a twist it is Ember.Object
       defaultValue: Ember.Object.create({id: 12, label: 'red'})
     }
   </pre>
 
-  <div>
-    <h3>Handlebar (FYI: the value is the object)</h3>
-  </div>
+  <h2>Handlebar (FYI: the value is the object)</h2>
   <pre>
     &#123;&#123;#bg-select selected=model.defaultValue as |bg|}}
       &#123;&#123;#bg.option value=""}}Select one&#123;&#123;/bg.option}}
@@ -34,12 +33,14 @@
   </pre>
 </div>
 <div class="row">
+  <h2>Result</h2>
   <div class="col-xs-3">
-    {{#bg-select class="form-control" onSelectChange=(action 'onChangeHandler') tabindex=2 selected=model.defaultValue as |bg|}}
-    {{#bg.option value=""}}Select one{{/bg.option}}
-    {{#each model.array1 as |el|}}
-    {{#bg.option value=el}}{{el.label}}{{/bg.option}}
-    {{/each}}
+    <label class="sr-only" id="dropdown-label">Select a colour</label>
+    {{#bg-select class="form-control" onSelectChange=(action 'onChangeHandler') aria-labelledby="dropdown-label" tabindex=2 selected=model.defaultValue as |bg|}}
+      {{#bg.option value=""}}Select one{{/bg.option}}
+      {{#each model.array1 as |el|}}
+        {{#bg.option value=el}}{{el.label}}{{/bg.option}}
+      {{/each}}
     {{/bg-select}}
   </div>
   <div class="col-xs-3">

--- a/tests/dummy/app/templates/components/dummy-component.hbs
+++ b/tests/dummy/app/templates/components/dummy-component.hbs
@@ -36,7 +36,13 @@
   <h2>Result</h2>
   <div class="col-xs-3">
     <label class="sr-only" id="dropdown-label">Select a colour</label>
-    {{#bg-select class="form-control" onSelectChange=(action 'onChangeHandler') aria-labelledby="dropdown-label" tabindex=2 selected=model.defaultValue as |bg|}}
+    {{#bg-select class="form-control"
+      onSelectChange=(action 'onChangeHandler')
+      aria-label="Select a colour"
+      tabindex=2
+      selected=model.defaultValue
+      as |bg|
+    }}
       {{#bg.option value=""}}Select one{{/bg.option}}
       {{#each model.array1 as |el|}}
         {{#bg.option value=el}}{{el.label}}{{/bg.option}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 
-module.exports = function(environment) {
-  let ENV = {
+module.exports = function (environment) {
+  const ENV = {
     modulePrefix: 'dummy',
     environment,
     rootURL: '/',

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,9 @@
-import { module } from 'qunit';
+import {module} from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import {Promise} from 'rsvp';
 
-export default function(name, options = {}) {
+export default function (name, options = {}) {
   module(name, {
     beforeEach() {
       this.application = startApp();
@@ -14,7 +14,7 @@ export default function(name, options = {}) {
     },
 
     afterEach() {
-      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      const afterEach = options.afterEach && options.afterEach.apply(this, arguments);
       return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,13 +1,13 @@
 import Application from '../../app';
 import config from '../../config/environment';
-import { assign } from '@ember/polyfills';
+import {assign} from '@ember/polyfills';
 import {run} from '@ember/runloop';
 
 export default function startApp(attrs) {
   let application;
 
   // use defaults, but you can override
-  let attributes = assign({}, config.APP, attrs);
+  const attributes = assign({}, config.APP, attrs);
 
   run(() => {
     application = Application.create(attributes);

--- a/tests/integration/components/bg-option/component-test.js
+++ b/tests/integration/components/bg-option/component-test.js
@@ -1,27 +1,27 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | bg-select/bg-option', function(hooks) {
+module('Integration | Component | bg-select/bg-option', function (hooks) {
   setupRenderingTest(hooks);
 
-test('didInsertElement hook', async function (assert) {
-  let moackValue = 'apple';
-  assert.expect(3);
+  test('didInsertElement hook', async function (assert) {
+    let mockValue = 'apple';
+    assert.expect(3);
 
-  this.set('onRegisterHandler', (id, value) => {
-    assert.equal(value, moackValue, 'should send the value of option');
-    assert.equal( this.$('option').attr('id'), id, 'should send the id of option');
+    this.set('onRegisterHandler', (id, value) => {
+      assert.equal(value, mockValue, 'should send the value of option');
+      assert.equal( this.$('option').attr('id'), id, 'should send the id of option');
+    });
+
+    this.set('value', mockValue);
+    await render(hbs`
+      {{#bg-option register=(action onRegisterHandler) value=value}}
+        template block text
+      {{/bg-option}}
+    `);
+
+    assert.equal(this.$().text().trim(), 'template block text');
   });
-
-  this.set('value', moackValue);
-  await render(hbs`
-    {{#bg-option register=(action onRegisterHandler) value=value}}
-      template block text
-    {{/bg-option}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
-});
 });

--- a/tests/integration/components/bg-option/component-test.js
+++ b/tests/integration/components/bg-option/component-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | bg-select/bg-option', function (hooks) {
   setupRenderingTest(hooks);
 
   test('didInsertElement hook', async function (assert) {
-    let mockValue = 'apple';
+    const mockValue = 'apple';
     assert.expect(3);
 
     this.set('onRegisterHandler', (id, value) => {

--- a/tests/integration/components/bg-select/component-test.js
+++ b/tests/integration/components/bg-select/component-test.js
@@ -39,9 +39,9 @@ module('Integration | Component | bg-select', function (hooks) {
 
   test('check select has aria-labelledby', async function (assert) {
     await render(hbs`
-      {{bg-select aria-labelledby="label"}}
+      {{bg-select aria-label="select something"}}
     `);
 
-    assert.equal(this.$('select').attr('aria-labelledby'), 'label', 'should have aria-labelledby attribute');
+    assert.equal(this.$('select').attr('aria-label'), 'select something', 'should self label');
   });
 });

--- a/tests/integration/components/bg-select/component-test.js
+++ b/tests/integration/components/bg-select/component-test.js
@@ -1,12 +1,12 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | bg-select', function(hooks) {
+module('Integration | Component | bg-select', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('changing "selected" value from outside', async function(assert) {
+  test('changing "selected" value from outside', async function (assert) {
     let values = [{
       label: 'label 1',
       aProp: 'abc'
@@ -33,8 +33,7 @@ module('Integration | Component | bg-select', function(hooks) {
 
     this.set('selected', values[2]);
 
-    assert.equal(this.$('option:selected').index(), 2, 'should select the required 3nd element');
+    assert.equal(this.$('option:selected').index(), 2, 'should select the required 3rd element');
     assert.equal(this.$('select').attr('tabindex'), 3);
-
   });
 });

--- a/tests/integration/components/bg-select/component-test.js
+++ b/tests/integration/components/bg-select/component-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | bg-select', function (hooks) {
   setupRenderingTest(hooks);
 
   test('changing "selected" value from outside', async function (assert) {
-    let values = [{
+    const values = [{
       label: 'label 1',
       aProp: 'abc'
     }, {
@@ -34,6 +34,14 @@ module('Integration | Component | bg-select', function (hooks) {
     this.set('selected', values[2]);
 
     assert.equal(this.$('option:selected').index(), 2, 'should select the required 3rd element');
-    assert.equal(this.$('select').attr('tabindex'), 3);
+    assert.equal(this.$('select').attr('tabindex'), 3, 'should have tabindex of 3');
+  });
+
+  test('check select has aria-labelledby', async function (assert) {
+    await render(hbs`
+      {{bg-select aria-labelledby="label"}}
+    `);
+
+    assert.equal(this.$('select').attr('aria-labelledby'), 'label', 'should have aria-labelledby attribute');
   });
 });


### PR DESCRIPTION
Add the `aria-label` attribute to bg-select (and do some linting). aXe complains when the associated label is visually hidden (even though that is an acceptable way to meet AA compliance), but self-labelling the dropdown keeps it AA compliant and stops aXe from complaining.